### PR TITLE
Bump quarkus plugin to version: 0.1.18

### DIFF
--- a/plugins/quarkus-backend/package.json
+++ b/plugins/quarkus-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qshift/plugin-quarkus-backend",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/quarkus/package.json
+++ b/plugins/quarkus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qshift/plugin-quarkus",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bump quarkus plugin to version: 0.1.18 in order to release it