### PR TITLE
Moving the react-router-dom dep within devDependency 

### DIFF
--- a/plugins/quarkus-backend/package.json
+++ b/plugins/quarkus-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qshift/plugin-quarkus-backend",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/quarkus-console/package.json
+++ b/plugins/quarkus-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qshift/plugin-quarkus-console",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,6 @@
     "@rjsf/utils": "^5.15.1",
     "axios": "^1.6.5",
     "react-use": "^17.2.4",
-    "react-router-dom": "^6.22.1",
     "styled-components": "^6.1.8"
   },
   "peerDependencies": {
@@ -55,6 +54,7 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
     "@types/styled-components": "^5.1.34",
+    "react-router-dom": "^6.22.1",
     "msw": "^1.0.0"
   },
   "resolutions": {

--- a/plugins/quarkus/package.json
+++ b/plugins/quarkus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qshift/plugin-quarkus",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Moving the react-router-dom dep within devDependency to avoid (I hope) to be download part of the quarkus-console module
- Bump version to 0.1.23 to prepare a new release