### PR TITLE
Fixed issue with field codeQuarkusUrl not set properly when value is …

### DIFF
--- a/plugins/quarkus/src/scaffolder/QuarkusExtensionList.tsx
+++ b/plugins/quarkus/src/scaffolder/QuarkusExtensionList.tsx
@@ -152,7 +152,7 @@ export const QuarkusExtensionList =  ({ onChange, rawErrors, required, formData,
         // TODO: Check if the code change does not break the logic of the plugin
         defaultValue: quarkusExtensions && quarkusExtensions.length > 0 ? [{ id: quarkusExtensions[0].id, name: quarkusExtensions[0].name }] : [],
         multiple: true,
-        options: quarkusExtensions,
+        options: quarkusExtensions.sort((a,b) => a.name.localeCompare(b.name)),
         getOptionLabel: (option: {id: string, name: string}) => option.id,
     });
 
@@ -165,18 +165,18 @@ export const QuarkusExtensionList =  ({ onChange, rawErrors, required, formData,
         headers: headers
     };
 
-  const codeQuarkusUrl = uiSchema && uiSchema['ui:options']?uiSchema['ui:options']?.codeQuarkusUrl : 'https://stage.code.quarkus.io';
-  const apiUrl = codeQuarkusUrl + '/api/extensions'
+  const codeQuarkusUrl = (uiSchema ?? {})['ui:options']?.codeQuarkusUrl ?? 'https://code.quarkus.io';
+  const apiUrl = `${codeQuarkusUrl}/api/extensions`
   const filter = (uiSchema ?? {})['ui:options']?.filter ?? {};
   const filteredExtensions = (filter as { extensions?: string[] })?.extensions ?? [];
   const filteredCategories = (filter as { categories?: string[] })?.categories ?? [];
   const filteredKeywords = (filter as { keywords?: string[] })?.keywords ?? [];
 
   const filterExtension = (e: QuarkusExtensionType) => {
-          const matchingCateogory = !filteredCategories || filteredCategories.length == 0 || filteredCategories.some(regex => !e.category || e.category.match(regex));
+          const matchingCategory = !filteredCategories || filteredCategories.length == 0 || filteredCategories.some(regex => !e.category || e.category.match(regex));
           const matchingName = !filteredExtensions || filteredExtensions.length == 0 || filteredExtensions.some(regex => e.id.match(regex));
           const matchingKeywords = !filteredKeywords || filteredKeywords.length == 0 || filteredKeywords.some(regex => !e.keywords || e.keywords.some(keyword => keyword.match(regex)));
-          return matchingCateogory && matchingKeywords && matchingName;
+          return matchingCategory && matchingKeywords && matchingName;
   }
 
     // Download the Component list


### PR DESCRIPTION
- Fixed issue with field `codeQuarkusUrl` not set properly when value is not declared within the template. 
- Sorting the list of the extensions declared as options

Remark: Template should be updated to define the filter
```
          type: array
          description: The list of alternative extensions
          ui:field: QuarkusExtensionList
          ui:options:
            # codeQuarkusUrl: https://code.quarkus.io
            filter:
              extensions:
                - io.quarkus:quarkus-resteasy-reactive-jackson
                - io.quarkus:quarkus-smallrye-openapi
                - io.quarkus:quarkus-smallrye-graphql
                - io.quarkus:quarkus-hibernate-orm-rest-data-panache
```

![Screenshot 2024-02-22 at 16 10 46](https://github.com/q-shift/backstage-plugins/assets/463790/55e36f45-2a36-4522-8d19-03ee3e21244d)
