### PR TITLE
Fix wrong input parameter used (custom_param -> node_version)

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version-file: ${{ inputs.custom_param }}
+        node-version: ${{ inputs.node_version }}
         cache: 'yarn'
 
     - name: Setup local Turbo cache

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 20.x ]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-for-release.yaml
+++ b/.github/workflows/pr-for-release.yaml
@@ -18,7 +18,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          node-version: [ 20.x ]
+          node-version: [20.x]
 
       steps:
         - name: Checkout code
@@ -27,7 +27,7 @@ jobs:
         - name: Setup Node.js
           uses: actions/setup-node@v4
           with:
-            node-version-file: ${{ matrix.node-version }}
+            node-version: ${{ matrix.node-version }}
             cache: 'yarn'
 
         - name: Build all plugins


### PR DESCRIPTION
- Fix wrong input parameter used (custom_param -> node_version). 
- Use the node version as parameter instead of node_version_file to configure actions/setup-node@v4