### PR TITLE
Fixes to the release PR

### DIFF
--- a/.github/workflows/pr-for-release.yaml
+++ b/.github/workflows/pr-for-release.yaml
@@ -82,9 +82,8 @@ jobs:
             body: |
               Pull request for release ${{ steps.calculate_next_version.outputs.version }}.
 
-              This pull request contains all the `package.json` files updated with the new release version
+              This pull request contains the plugin `package.json` files updated with the new release version
 
-                * `package.json`
                 * `plugins/quarkus/package.json`
                 * `plugins/quarkus-backend/package.json`
                 * `plugins/quarkus-console/package.json`

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn.lock
 # npm
 **/node_modules
 package-lock.json
+
+# Test results
+plugins/*/coverage


### PR DESCRIPTION
These changes contain fixes to the Release PR:

- Remove the root `package.json` file from the hardcoded list of changed files
- Improve the PR body text
- Added the plugins test `coverage` report sub-folders to the git ignore list so they don't get pushed into the repository