### PR TITLE
Add permission to write contents to the tag and create release workflow

### DIFF
--- a/.github/workflows/tag-and-create-release.yaml
+++ b/.github/workflows/tag-and-create-release.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise pushing the TAG will fail.