### PR TITLE
Improve release process

### DIFF
--- a/.github/workflows/pr-for-release.yaml
+++ b/.github/workflows/pr-for-release.yaml
@@ -88,3 +88,5 @@ jobs:
                 * `plugins/quarkus-backend/package.json`
                 * `plugins/quarkus-console/package.json`
             base: main
+            labels: |
+              release

--- a/.github/workflows/pr-for-release.yaml
+++ b/.github/workflows/pr-for-release.yaml
@@ -72,6 +72,14 @@ jobs:
             jq '.version = "${{ steps.calculate_next_version.outputs.version }}"' plugins/quarkus-backend/package.json | sponge plugins/quarkus-backend/package.json
             jq '.version = "${{ steps.calculate_next_version.outputs.version }}"' plugins/quarkus-console/package.json | sponge plugins/quarkus-console/package.json
 
+        - name: List package.json files
+          id: list_package_json_files
+          run: |
+            PLUGIN_FILES=$(find plugins/ -maxdepth 2 -name package.json -exec echo '  - `'{}'`' \;)
+            echo "PLUGIN_FILES_MD<<EOF" >> $GITHUB_ENV
+            echo "$PLUGIN_FILES" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+
         - name: Create pull request for release
           id: create_pr
           uses: peter-evans/create-pull-request@v6
@@ -84,9 +92,7 @@ jobs:
 
               This pull request contains the plugin `package.json` files updated with the new release version
 
-                * `plugins/quarkus/package.json`
-                * `plugins/quarkus-backend/package.json`
-                * `plugins/quarkus-console/package.json`
+              ${{ env.PLUGIN_FILES_MD }}
             base: main
             labels: |
               release

--- a/.github/workflows/tag-and-create-release.yaml
+++ b/.github/workflows/tag-and-create-release.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.title, 'Release:')
+    if: startsWith(github.event.pull_request.title, 'Release:') && github.event.pull_request.merged == true
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/tag-and-create-release.yaml
+++ b/.github/workflows/tag-and-create-release.yaml
@@ -35,6 +35,38 @@ jobs:
           git tag -a "$release_version" -m "Version $release_version"
           git push --follow-tags
 
+      - name: Build Changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        id: generate_changelog
+        with:
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+              "categories": [
+                {
+                    "title": "## 🎉 Exciting New Features",
+                    "labels": ["enhancement"]
+                },
+                {
+                    "title": "## 🐞 Bug Fixes",
+                    "labels": ["bug"]
+                },
+                {
+                    "title": "## 💬 Other Changes",
+                    "labels": ["*"]
+                },
+                {
+                    "title": "## 📦 Dependencies",
+                    "labels": ["dependencies"]
+                }
+              ],
+              "ignore_labels": [
+                "release"
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -45,5 +77,7 @@ jobs:
           release_name: Release ${{ steps.get_version_number.outputs.version }}
           body: |
             Release ${{ steps.get_version_number.outputs.version }}
+
+            ${{steps.generate_changelog.outputs.changelog}}
           draft: false
           prerelease: false

--- a/.github/workflows/tag-and-create-release.yaml
+++ b/.github/workflows/tag-and-create-release.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           configurationJson: |
             {
-              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>💬 Other Changes</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
               "categories": [
                 {
                     "title": "## 🎉 Exciting New Features",
@@ -50,10 +50,6 @@ jobs:
                 {
                     "title": "## 🐞 Bug Fixes",
                     "labels": ["bug"]
-                },
-                {
-                    "title": "## 💬 Other Changes",
-                    "labels": ["*"]
                 },
                 {
                     "title": "## 📦 Dependencies",

--- a/.github/workflows/tag-and-create-release.yaml
+++ b/.github/workflows/tag-and-create-release.yaml
@@ -63,6 +63,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: List package URL
+        id: list_package_url
+        run: |
+          PACKAGE_URL=$(find plugins/ -maxdepth 2 -name package.json -exec sh -c "echo -n '  - https://www.npmjs.com/package/' ; cat {} | jq -j '.name' ; echo -n /v/ ; cat {} | jq -j '.version' ; printf '\n'" \;)
+          echo "PACKAGE_URL_MD<<EOF" >> $GITHUB_ENV
+          echo "$PACKAGE_URL" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -72,8 +80,14 @@ jobs:
           tag_name: ${{ steps.get_version_number.outputs.version }}
           release_name: Release ${{ steps.get_version_number.outputs.version }}
           body: |
-            Release ${{ steps.get_version_number.outputs.version }}
+            **Release ${{ steps.get_version_number.outputs.version }}**
+
+            ## Changes
 
             ${{steps.generate_changelog.outputs.changelog}}
+
+            ## npm packages
+
+            ${{ env.PACKAGE_URL_MD }}
           draft: false
           prerelease: false


### PR DESCRIPTION
* Add release label to the release PR
  *  this will allow filtering the release PR from the changelog
  * requires the `release` label to actually be created on the repository
* Skip the release workflow if the release PR is closed without being merged
* Generate change log and add it's text to the release body