### PR TITLE
Fixes GH workflow error when generated document doesn't have changes

### DIFF
--- a/.github/workflows/pr-update-doc.yaml
+++ b/.github/workflows/pr-update-doc.yaml
@@ -49,6 +49,7 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           m4 README.m4.template.md > README.md
+          set +e
           git add README.md
           git commit -m "Generated main README.md file from template"
           git push


### PR DESCRIPTION
Prevent the _Update the documentation on PR merge_ GH workflow from failing when it doesn't generate changes.

Closes #89 