### PR TITLE
Remove non needed defaultValue as it always pickup the first value of…

### DIFF
--- a/plugins/quarkus/src/scaffolder/QuarkusExtensionList.tsx
+++ b/plugins/quarkus/src/scaffolder/QuarkusExtensionList.tsx
@@ -199,7 +199,7 @@ export const QuarkusExtensionList = ({ onChange, rawErrors, required, formData, 
         */
         if (formData && formData?.length > 0 ) {
             matchingExtensions = uniqueExtensions(quarkusExtensions).filter((extension) => formData.includes(extension.id));
-            console.log('Matching extensions from formData: ',matchingExtensions);
+            // console.log('Matching extensions from formData: ',matchingExtensions);
         }
 
     }, []);


### PR DESCRIPTION
- Remove non needed defaultValue as it always pickup the first value of the list.
- Implement the needed code to restore values selected when we return back to the screen of the extensionsList field.
- Issue: #92

This PR has tested successfully using the following test cases
```
        extensions:
          title: Alternative Extensions
          type: array
          description: The list of alternative extensions
          ui:field: QuarkusExtensionList

AND

        extensions:
          title: Filter Extensions
          type: array
          description: The list of the extensions recommended
          ui:field: QuarkusExtensionList
          ui:options:
            filter:
              extensions:
                - io.quarkus:quarkus-resteasy-reactive-jackson
                - io.quarkus:quarkus-smallrye-openapi
                - io.quarkus:quarkus-smallrye-graphql
                - io.quarkus:quarkus-hibernate-orm-rest-data-panache
```