### PR TITLE
docs: fix wrong URL for images

### DIFF
--- a/plugins/quarkus/README.md
+++ b/plugins/quarkus/README.md
@@ -99,13 +99,13 @@ If you would like to use a different code generator server, set the following pr
 ```
 
 Quarkus Extension List - default (field):
-![extensions-1.png](plugins%2Fquarkus%2Fdoc%2Fextensions-1.png)
+![extensions-1.png](/plugins%2Fquarkus%2Fdoc%2Fextensions-1.png)
 
 Quarkus Extension List - Select (field):
-![extensions-2.png](plugins%2Fquarkus%2Fdoc%2Fextensions-2.png)
+![extensions-2.png](/plugins%2Fquarkus%2Fdoc%2Fextensions-2.png)
 
 Quarkus Extension List - Added (field):
-![extensions-3.png](plugins%2Fquarkus%2Fdoc%2Fextensions-3.png)
+![extensions-3.png](/plugins%2Fquarkus%2Fdoc%2Fextensions-3.png)
 
 ### Quarkus Quickstart picker field
 

--- a/plugins/quarkus/README.md
+++ b/plugins/quarkus/README.md
@@ -158,10 +158,10 @@ spec:
 When done, you will be able to create a new Quarkus project from the quickstart selected.
 
 Quarkus Quickstart Picker - default (field):
-![quickstart-1.png](plugins/quarkus/doc/quickstart-1.png)
+![quickstart-1.png](/plugins/quarkus/doc/quickstart-1.png)
 
 Quarkus Quickstart Picker - select (field):
-![quickstart-2.png](plugins/quarkus/doc/quickstart-2.png)
+![quickstart-2.png](/plugins/quarkus/doc/quickstart-2.png)
 
 ### Quarkus Version list field
 
@@ -214,7 +214,7 @@ When done, you will be able to select the quarkus version to be used to scaffold
 your quarkus project
 
 Quarkus Version list - Select (field):
-![version-list.png](plugins/quarkus/doc/version-list.png)
+![version-list.png](/plugins/quarkus/doc/version-list.png)
 
 Quarkus Version list - Recommended (field):
-![version-recommended.png](plugins/quarkus/doc/version-recommended.png)
+![version-recommended.png](/plugins/quarkus/doc/version-recommended.png)


### PR DESCRIPTION
Local links used in the different `README.md` files must be relative to the repository root otherwise they won't be correctly shown when the documentation is applied on the root `README.md` file.

Closes #97 